### PR TITLE
feat: soft-delete karyawan + restore & admin reset password

### DIFF
--- a/.cursor/rules/no-destructive-db-env.mdc
+++ b/.cursor/rules/no-destructive-db-env.mdc
@@ -1,0 +1,26 @@
+---
+description: Larang operasi yang merusak database atau .env
+alwaysApply: true
+---
+
+# Jangan Rusak DB / Env
+
+Dilarang keras menjalankan apa pun yang mengubah data database, skema, atau file environment.
+
+## Dilarang
+
+- `INSERT`, `UPDATE`, `DELETE`, `TRUNCATE`, `DROP`, `ALTER`
+- `php artisan migrate` / `migrate:fresh` / `migrate:refresh` / `migrate:rollback` / `db:seed` / `db:wipe`
+- Modifikasi file `.env` atau credentials
+- Menulis/menghapus data lewat tinker, raw SQL, atau script yang menyentuh DB production/dev yang dipakai
+- Menggunakan `DB::`, Eloquent `create`/`update`/`delete`/`save` dalam perintah shell/artisan yang dijalankan agent
+
+## Diizinkan
+
+- Baca saja: `SELECT`, `php artisan tinker` read-only, inspeksi schema tanpa ubah
+- Baca `.env` jika perlu debug, tapi jangan edit
+- Ubah kode aplikasi (model, migration file di repo) hanya jika user minta eksplisit — tetap **jangan jalankan** migration-nya
+
+## Jika ragu
+
+Tanya user dulu. Default = tidak menyentuh DB/env.

--- a/app/Http/Controllers/PasswordController.php
+++ b/app/Http/Controllers/PasswordController.php
@@ -51,7 +51,7 @@ class PasswordController extends Controller
             return back()->withErrors(['current_password' => 'Password Salah']);
         }
 
-        $user->password = Hash::make($request->password);
+        $user->password = $request->password;
         $user->save();
 
         return redirect()->back()->with('success', 'Password Berhasil Diubah!');

--- a/app/Http/Controllers/admin/AdminKaryawanController.php
+++ b/app/Http/Controllers/admin/AdminKaryawanController.php
@@ -15,6 +15,7 @@ use App\Models\SisaCuti;
 use App\Models\KaryawanCutiBersama;
 use App\Models\RiwayatCuti;
 use App\Models\PermintaanCuti;
+use Illuminate\Support\Facades\Schema;
 
 
 class AdminKaryawanController extends Controller
@@ -42,6 +43,11 @@ class AdminKaryawanController extends Controller
         $search = $request->input('search', '');
 
         $query = Karyawan::with('posisi.unitKerja');
+
+        $status = $request->input('status', 'active');
+        if ($status === 'trashed') {
+            $query->onlyTrashed();
+        }
 
         if ($search) {
             $query->where(function($q) use ($search) {
@@ -130,72 +136,109 @@ class AdminKaryawanController extends Controller
 //soft delete
     public function delete($id)
     {
-        // Check if the employee is associated with a user
-        $user = User::withTrashed()->where('id_karyawan', $id)->first();
-        if ($user) {
-            // If the user exists and is not soft deleted
-            if (!$user->trashed()) {
-                return redirect()->back()->with('warning_message', 'Data karyawan ini ada di tabel users dan tidak dapat dihapus. Ganti id_karyawan di User terlebih dahulu');
-            }
-            // If the user is soft deleted, proceed with deletion of karyawan
-        }
-
-        // Find the employee
         $karyawan = Karyawan::find($id);
-
-        // Check if the employee exists
         if (!$karyawan) {
             return redirect()->back()->with('warning_message', 'Data karyawan tidak ditemukan');
         }
 
-        // Delete related records
-        SisaCuti::where('id_karyawan', $id)->delete();
-        KaryawanCutiBersama::where('id_karyawan', $id)->delete();
-        $permintaanCutiIds = PermintaanCuti::where('id_karyawan', $id)->pluck('id');
-        RiwayatCuti::whereIn('id_permintaan_cuti', $permintaanCutiIds)->delete();
-        PermintaanCuti::where('id_karyawan', $id)->delete();
-        DB::table('log_pengurangan_cuti')->where('id_karyawan', $id)->update(['deleted_at' => now()]);
+        DB::transaction(function () use ($id) {
+            $deletedAt = now();
 
-        // Finally, delete the employee
-        $karyawan->delete();
+            User::where('id_karyawan', $id)->get()->each(function (User $user) use ($deletedAt) {
+                $user->deleted_at = $deletedAt;
+                $user->save();
+            });
 
-        return redirect()->back()->with('error_message', 'Data karyawan berhasil dihapus');
+            SisaCuti::where('id_karyawan', $id)->whereNull('deleted_at')->get()->each(function ($row) use ($deletedAt) {
+                $row->deleted_at = $deletedAt;
+                $row->save();
+            });
+
+            KaryawanCutiBersama::where('id_karyawan', $id)->whereNull('deleted_at')->get()->each(function ($row) use ($deletedAt) {
+                $row->deleted_at = $deletedAt;
+                $row->save();
+            });
+
+            $permintaan = PermintaanCuti::where('id_karyawan', $id)->whereNull('deleted_at')->get();
+            $permintaanIds = $permintaan->pluck('id');
+
+            RiwayatCuti::whereIn('id_permintaan_cuti', $permintaanIds)->whereNull('deleted_at')->get()->each(function ($row) use ($deletedAt) {
+                $row->deleted_at = $deletedAt;
+                $row->save();
+            });
+
+            $permintaan->each(function ($row) use ($deletedAt) {
+                $row->deleted_at = $deletedAt;
+                $row->save();
+            });
+
+            if (Schema::hasTable('log_pengurangan_cuti') && Schema::hasColumn('log_pengurangan_cuti', 'deleted_at')) {
+                DB::table('log_pengurangan_cuti')
+                    ->where('id_karyawan', $id)
+                    ->whereNull('deleted_at')
+                    ->update(['deleted_at' => $deletedAt]);
+            }
+
+            $karyawan = Karyawan::find($id);
+            $karyawan->deleted_at = $deletedAt;
+            $karyawan->save();
+        });
+
+        return redirect()->back()->with('error_message', 'Data karyawan berhasil dihapus (soft delete)');
     }
 
+    public function restore($id)
+    {
+        $karyawan = Karyawan::withTrashed()->find($id);
+        if (!$karyawan || !$karyawan->trashed()) {
+            return redirect()->back()->with('warning_message', 'Data karyawan terhapus tidak ditemukan');
+        }
 
-//delete semua data karyawan sampai database
-//     public function delete($id)
-// {
-//     // Check if the employee is associated with a user
-//     $user = DB::table('users')->where('id_karyawan', $id)->first();
-//     if ($user) {
-//         return redirect()->back()->with('warning_message', 'Data karyawan ini ada di tabel users dan tidak dapat dihapus. Ganti id_karyawan di User terlebih dahulu');
-//     }
+        DB::transaction(function () use ($karyawan) {
+            $marker = $karyawan->deleted_at;
+            $from = $marker->copy()->subSeconds(2);
+            $to = $marker->copy()->addSeconds(2);
 
-//     DB::transaction(function () use ($id) {
-//         // Find the employee
-//         $karyawan = Karyawan::find($id);
+            User::withTrashed()
+                ->where('id_karyawan', $karyawan->id)
+                ->whereBetween('deleted_at', [$from, $to])
+                ->restore();
 
-//         // Check if the employee exists
-//         if (!$karyawan) {
-//             return redirect()->back()->with('warning_message', 'Data karyawan tidak ditemukan');
-//         }
+            SisaCuti::withTrashed()
+                ->where('id_karyawan', $karyawan->id)
+                ->whereBetween('deleted_at', [$from, $to])
+                ->restore();
 
-//         // Delete related records
-//         SisaCuti::where('id_karyawan', $id)->delete();
-//         KaryawanCutiBersama::where('id_karyawan', $id)->delete();
-//         $permintaanCutiIds = PermintaanCuti::where('id_karyawan', $id)->pluck('id');
-//         RiwayatCuti::whereIn('id_permintaan_cuti', $permintaanCutiIds)->delete();
-//         PermintaanCuti::where('id_karyawan', $id)->delete();
-//         DB::table('log_pengurangan_cuti')->where('id_karyawan', $id)->delete();
+            KaryawanCutiBersama::withTrashed()
+                ->where('id_karyawan', $karyawan->id)
+                ->whereBetween('deleted_at', [$from, $to])
+                ->restore();
 
-//         // Finally, delete the employee
-//         $karyawan->delete();
-//     });
+            $permintaanIds = PermintaanCuti::withTrashed()
+                ->where('id_karyawan', $karyawan->id)
+                ->whereBetween('deleted_at', [$from, $to])
+                ->pluck('id');
 
-//     return redirect()->back()->with('error_message', 'Data karyawan berhasil dihapus');
-// }
+            RiwayatCuti::withTrashed()
+                ->whereIn('id_permintaan_cuti', $permintaanIds)
+                ->whereBetween('deleted_at', [$from, $to])
+                ->restore();
 
+            PermintaanCuti::withTrashed()
+                ->where('id_karyawan', $karyawan->id)
+                ->whereBetween('deleted_at', [$from, $to])
+                ->restore();
 
+            if (Schema::hasTable('log_pengurangan_cuti') && Schema::hasColumn('log_pengurangan_cuti', 'deleted_at')) {
+                DB::table('log_pengurangan_cuti')
+                    ->where('id_karyawan', $karyawan->id)
+                    ->whereBetween('deleted_at', [$from, $to])
+                    ->update(['deleted_at' => null]);
+            }
 
+            $karyawan->restore();
+        });
+
+        return redirect()->back()->with('message', 'Data karyawan berhasil dipulihkan');
+    }
 }

--- a/app/Http/Controllers/admin/AdminUserController.php
+++ b/app/Http/Controllers/admin/AdminUserController.php
@@ -88,14 +88,28 @@ class AdminUserController extends Controller
         // }
 
         DB::transaction(function () use ($validate) {
-            $user = User::create([
-                    'username' => $validate['username'],
-                    'password' => bcrypt($validate['password']),
-                    'id_karyawan' => $validate['id_karyawan'],
+            User::create([
+                'username' => $validate['username'],
+                'password' => $validate['password'],
+                'id_karyawan' => $validate['id_karyawan'],
             ]);
         });
 
         return redirect()->back()->with('message', 'User berhasil ditambahkan!');
+    }
+
+    public function resetPassword(Request $request)
+    {
+        $validate = $request->validate([
+            'id' => 'required|exists:users,id',
+            'password' => 'required|min:3|confirmed',
+        ]);
+
+        $user = User::findOrFail($validate['id']);
+        $user->password = $validate['password'];
+        $user->save();
+
+        return redirect()->back()->with('message', 'Password berhasil direset');
     }
 
 

--- a/database/migrations/2026_07_27_000001_add_deleted_at_to_soft_delete_tables.php
+++ b/database/migrations/2026_07_27_000001_add_deleted_at_to_soft_delete_tables.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private array $tables = [
+        'users',
+        'karyawan',
+        'sisa_cuti',
+        'karyawan_cuti_bersama',
+        'permintaan_cuti',
+        'riwayat_cuti',
+        'log_pengurangan_cuti',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            if (!Schema::hasTable($table)) {
+                continue;
+            }
+            if (!Schema::hasColumn($table, 'deleted_at')) {
+                Schema::table($table, function (Blueprint $blueprint) {
+                    $blueprint->softDeletes();
+                });
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $table) {
+            if (Schema::hasTable($table) && Schema::hasColumn($table, 'deleted_at')) {
+                Schema::table($table, function (Blueprint $blueprint) {
+                    $blueprint->dropSoftDeletes();
+                });
+            }
+        }
+    }
+};

--- a/docs/superpowers/plans/2026-07-27-soft-delete-karyawan-login-fix.md
+++ b/docs/superpowers/plans/2026-07-27-soft-delete-karyawan-login-fix.md
@@ -1,0 +1,620 @@
+# Soft-delete Karyawan + Login Password Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Perbaiki double-hash password (agar login/reset bekerja), dan soft-delete karyawan yang sekaligus soft-delete user terkait, dengan kemampuan restore.
+
+**Architecture:** Minimal perubahan di controller/view yang sudah ada. `User` cast `hashed` jadi satu-satunya hasher. Soft-delete/restore di `AdminKaryawanController` dalam transaksi DB, matching related rows lewat timestamp `deleted_at` karyawan. UI admin menambah filter trashed + reset password.
+
+**Tech Stack:** Laravel (PHP), Blade + jQuery fetch tables, Eloquent SoftDeletes, PHPUnit + sqlite `:memory:` (`phpunit.xml`).
+
+## Global Constraints
+
+- **Jangan** menjalankan migrate / seed / INSERT / UPDATE / DELETE terhadap DB production di `.env` tanpa perintah eksplisit user.
+- **Jangan** mengedit `.env`.
+- Test **hanya** lewat `phpunit.xml` (sqlite `:memory:`).
+- **Jangan commit** sampai user minta (skip semua step Commit di plan ini).
+- Spec: `docs/superpowers/specs/2026-07-27-soft-delete-karyawan-login-fix-design.md`.
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `database/migrations/2026_07_27_000001_add_deleted_at_to_soft_delete_tables.php` | Tambah `deleted_at` jika belum ada (file saja; jangan auto-migrate prod) |
+| `app/Http/Controllers/admin/AdminUserController.php` | Create user tanpa bcrypt manual; reset password |
+| `app/Http/Controllers/PasswordController.php` | Change password tanpa `Hash::make` manual |
+| `app/Http/Controllers/admin/AdminKaryawanController.php` | Cascade soft-delete + restore |
+| `routes/web.php` | Route restore + reset password |
+| `resources/views/admin/karyawan.blade.php` | Filter status, restore, fix delete URL |
+| `resources/views/admin/user.blade.php` | Modal reset password, fix delete URL |
+| `tests/Feature/PasswordHashingTest.php` | Auth setelah create/reset |
+| `tests/Feature/KaryawanSoftDeleteTest.php` | Soft-delete + restore + login gate |
+
+---
+
+### Task 1: Migration `deleted_at` (schema alignment)
+
+**Files:**
+- Create: `database/migrations/2026_07_27_000001_add_deleted_at_to_soft_delete_tables.php`
+- Test: verified when later Feature tests use `RefreshDatabase`
+
+**Interfaces:**
+- Consumes: none
+- Produces: nullable `deleted_at` on `users`, `karyawan`, `sisa_cuti`, `karyawan_cuti_bersama`, `permintaan_cuti`, `riwayat_cuti`, `log_pengurangan_cuti` (idempotent: only add if missing)
+
+**Notes:** Dump SQL & migration lama **tidak** punya `deleted_at`, sementara model sudah SoftDeletes. Tanpa kolom ini soft-delete crash. **Jangan** `php artisan migrate` ke DB `.env` kecuali user minta.
+
+- [ ] **Step 1: Create migration file**
+
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private array $tables = [
+        'users',
+        'karyawan',
+        'sisa_cuti',
+        'karyawan_cuti_bersama',
+        'permintaan_cuti',
+        'riwayat_cuti',
+        'log_pengurangan_cuti',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            if (!Schema::hasTable($table)) {
+                continue;
+            }
+            if (!Schema::hasColumn($table, 'deleted_at')) {
+                Schema::table($table, function (Blueprint $blueprint) {
+                    $blueprint->softDeletes();
+                });
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $table) {
+            if (Schema::hasTable($table) && Schema::hasColumn($table, 'deleted_at')) {
+                Schema::table($table, function (Blueprint $blueprint) {
+                    $blueprint->dropSoftDeletes();
+                });
+            }
+        }
+    }
+};
+```
+
+- [ ] **Step 2: Skip commit** (user: jangan commit dulu)
+
+---
+
+### Task 2: Fix double-hash + admin reset password (backend)
+
+**Files:**
+- Modify: `app/Http/Controllers/admin/AdminUserController.php` (`tambahUser` ~L90–95; add `resetPassword`)
+- Modify: `app/Http/Controllers/PasswordController.php` (L54–55)
+- Modify: `routes/web.php` (admin user group ~L105–113)
+- Create: `tests/Feature/PasswordHashingTest.php`
+
+**Interfaces:**
+- Consumes: `User` cast `'password' => 'hashed'`
+- Produces:
+  - `AdminUserController::tambahUser` stores plain password string
+  - `AdminUserController::resetPassword(Request $request): RedirectResponse` — validates `id` (exists:users), `password` (required|min:3|confirmed)
+  - Route name `admin.user.reset-password` → `PUT /admin/user/reset-password`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/Feature/PasswordHashingTest.php`. `UserFactory` di repo **out of sync** (pakai `name`/`email`); jangan pakai factory. Buat schema minimal di `setUp` **atau** pakai `RefreshDatabase` jika full migrate jalan di sqlite.
+
+Prefer approach yang stabil di sqlite: helper trait di test file yang `Schema::create` tabel minimal (`role`, `unit_kerja`, `posisi`, `karyawan`, `users` + `deleted_at`), tanpa menjalankan seluruh migration stack (banyak FK/enum bisa fragile). Contoh:
+
+```php
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Karyawan;
+use App\Models\Posisi;
+use App\Models\Role;
+use App\Models\UnitKerja;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Tests\TestCase;
+
+class PasswordHashingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->createMinimalAuthSchema();
+    }
+
+    private function createMinimalAuthSchema(): void
+    {
+        Schema::dropIfExists('users');
+        Schema::dropIfExists('karyawan');
+        Schema::dropIfExists('posisi');
+        Schema::dropIfExists('role');
+        Schema::dropIfExists('unit_kerja');
+
+        Schema::create('unit_kerja', function (Blueprint $t) {
+            $t->id();
+            $t->string('kode_unit_kerja')->nullable();
+            $t->string('nama_unit_kerja')->nullable();
+            $t->boolean('is_kebun')->default(0);
+            $t->timestamps();
+        });
+        Schema::create('role', function (Blueprint $t) {
+            $t->id();
+            $t->string('nama_role');
+            $t->timestamps();
+        });
+        Schema::create('posisi', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('id_unit_kerja');
+            $t->unsignedBigInteger('id_role');
+            $t->string('jabatan')->nullable();
+            $t->timestamps();
+        });
+        Schema::create('karyawan', function (Blueprint $t) {
+            $t->id();
+            $t->string('nik');
+            $t->string('nama');
+            $t->string('jabatan')->nullable();
+            $t->date('tmt_bekerja')->nullable();
+            $t->date('tgl_diangkat_staf')->nullable();
+            $t->unsignedBigInteger('id_posisi');
+            $t->timestamps();
+            $t->softDeletes();
+        });
+        Schema::create('users', function (Blueprint $t) {
+            $t->id();
+            $t->string('username');
+            $t->string('password');
+            $t->unsignedBigInteger('id_karyawan');
+            $t->string('kode_unit')->nullable();
+            $t->rememberToken();
+            $t->timestamps();
+            $t->softDeletes();
+        });
+    }
+
+    private function seedManajerUser(string $username, string $plainPassword): User
+    {
+        $unit = UnitKerja::create(['kode_unit_kerja' => 'T1', 'nama_unit_kerja' => 'Test', 'is_kebun' => 0]);
+        $role = Role::create(['nama_role' => 'manajer']);
+        $posisi = Posisi::create(['id_unit_kerja' => $unit->id, 'id_role' => $role->id, 'jabatan' => 'Manajer']);
+        $karyawan = Karyawan::create([
+            'nik' => '1001',
+            'nama' => 'Test Manajer',
+            'jabatan' => 'Manajer',
+            'tmt_bekerja' => '2020-01-01',
+            'id_posisi' => $posisi->id,
+        ]);
+        return User::create([
+            'username' => $username,
+            'password' => $plainPassword, // MUST be hashed once by cast
+            'id_karyawan' => $karyawan->id,
+        ]);
+    }
+
+    public function test_user_create_with_plain_password_authenticates(): void
+    {
+        $user = $this->seedManajerUser('palai_manajer', 'secret123');
+        $this->assertTrue(Hash::check('secret123', $user->fresh()->password));
+        $this->assertTrue(Auth::attempt(['username' => 'palai_manajer', 'password' => 'secret123']));
+    }
+
+    public function test_bcrypt_before_cast_breaks_login(): void
+    {
+        // Documents the bug we are fixing: double hash would fail Auth::attempt
+        $unit = UnitKerja::create(['kode_unit_kerja' => 'T2', 'nama_unit_kerja' => 'Test2', 'is_kebun' => 0]);
+        $role = Role::create(['nama_role' => 'manajer']);
+        $posisi = Posisi::create(['id_unit_kerja' => $unit->id, 'id_role' => $role->id, 'jabatan' => 'Manajer']);
+        $karyawan = Karyawan::create([
+            'nik' => '1002', 'nama' => 'X', 'jabatan' => 'M', 'tmt_bekerja' => '2020-01-01', 'id_posisi' => $posisi->id,
+        ]);
+        $user = new User();
+        $user->username = 'broken_user';
+        $user->id_karyawan = $karyawan->id;
+        $user->password = bcrypt('secret123'); // pre-hash then cast hashes again
+        $user->save();
+        $this->assertFalse(Auth::attempt(['username' => 'broken_user', 'password' => 'secret123']));
+    }
+}
+```
+
+Sesuaikan nama kolom `nik`/`tmt_bekerja` dengan yang dipakai model fillable (bukan `NIK`/`TMT_bekerja` dari dump lama) — model fillable memakai lowercase.
+
+- [ ] **Step 2: Run tests — expect create/auth PASS already on model path; document double-hash FAIL**
+
+Run: `php artisan test --filter=PasswordHashingTest`
+
+Expected: `test_user_create_with_plain_password_authenticates` PASS; `test_bcrypt_before_cast_breaks_login` PASS (assertFalse).
+
+- [ ] **Step 3: Fix controllers**
+
+In `AdminUserController::tambahUser`, change:
+
+```php
+'password' => $validate['password'], // was bcrypt(...)
+```
+
+In `PasswordController::changePassword`, change:
+
+```php
+$user->password = $request->password; // was Hash::make(...)
+$user->save();
+```
+
+Add to `AdminUserController`:
+
+```php
+public function resetPassword(Request $request)
+{
+    $validate = $request->validate([
+        'id' => 'required|exists:users,id',
+        'password' => 'required|min:3|confirmed',
+    ]);
+
+    $user = User::findOrFail($validate['id']);
+    $user->password = $validate['password'];
+    $user->save();
+
+    return redirect()->back()->with('message', 'Password berhasil direset');
+}
+```
+
+In `routes/web.php` inside `admin/user` group:
+
+```php
+Route::put('/reset-password', [AdminUserController::class, 'resetPassword'])->name('admin.user.reset-password');
+```
+
+- [ ] **Step 4: Extend test for reset password**
+
+```php
+public function test_admin_reset_password_allows_login_with_new_password(): void
+{
+    $user = $this->seedManajerUser('reset_me', 'oldpass');
+    // Simulate admin reset (same code path as controller)
+    $user->password = 'newpass99';
+    $user->save();
+    $this->assertFalse(Auth::attempt(['username' => 'reset_me', 'password' => 'oldpass']));
+    $this->assertTrue(Auth::attempt(['username' => 'reset_me', 'password' => 'newpass99']));
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `php artisan test --filter=PasswordHashingTest`  
+Expected: all PASS
+
+- [ ] **Step 6: Skip commit**
+
+---
+
+### Task 3: Soft-delete cascade + restore (backend)
+
+**Files:**
+- Modify: `app/Http/Controllers/admin/AdminKaryawanController.php` (`delete` L130–163; add `restore`)
+- Modify: `routes/web.php` (karyawan group)
+- Create: `tests/Feature/KaryawanSoftDeleteTest.php`
+
+**Interfaces:**
+- Consumes: SoftDeletes on `Karyawan`, `User`, `SisaCuti`, `KaryawanCutiBersama`, `PermintaanCuti`, `RiwayatCuti`
+- Produces:
+  - `delete($id)`: cascade soft-delete users + related + karyawan; no “user exists” blocker
+  - `restore($id)`: restore karyawan + users + related rows whose `deleted_at` matches karyawan’s pre-restore `deleted_at` (±2 seconds window)
+  - Route `POST /admin/karyawan/{id}/restore` name `admin.karyawan.restore`
+
+- [ ] **Step 1: Write failing feature tests**
+
+Reuse minimal schema from Task 2; extend with empty related tables if needed for delete path. Core assertions:
+
+```php
+public function test_soft_delete_karyawan_soft_deletes_users_and_blocks_login(): void
+{
+    // seed user+karyawan like Task 2
+    // call controller delete OR replicate transaction logic under test via HTTP actingAs admin
+    // assert Karyawan::find($id) === null
+    // assert Karyawan::withTrashed()->find($id)->trashed()
+    // assert User::where('username', $u)->first() === null
+    // assert User::withTrashed()->where('username', $u)->first()->trashed()
+    // assert Auth::attempt([...]) === false
+}
+
+public function test_restore_karyawan_restores_user_and_login(): void
+{
+    // soft delete then restore
+    // assert Auth::attempt succeeds again
+}
+```
+
+Prefer testing via HTTP with `actingAs($adminUser)` and middleware bypass if `admin.auth` hard to satisfy — or call controller methods directly with `app(AdminKaryawanController::class)->delete($id)` inside a test request. Simplest reliable path: **extract transaction into private methods and invoke controller from test with `$this->withoutMiddleware()`** on routes.
+
+Example HTTP:
+
+```php
+$this->withoutMiddleware();
+$this->delete('/admin/karyawan/'.$karyawan->id)->assertRedirect();
+$this->post('/admin/karyawan/'.$karyawan->id.'/restore')->assertRedirect();
+```
+
+- [ ] **Step 2: Run — expect FAIL** (restore missing / delete still blocks)
+
+Run: `php artisan test --filter=KaryawanSoftDeleteTest`
+
+- [ ] **Step 3: Implement `delete` and `restore`**
+
+Replace `delete` body roughly with:
+
+```php
+public function delete($id)
+{
+    $karyawan = Karyawan::find($id);
+    if (!$karyawan) {
+        return redirect()->back()->with('warning_message', 'Data karyawan tidak ditemukan');
+    }
+
+    DB::transaction(function () use ($id) {
+        $deletedAt = now();
+
+        User::where('id_karyawan', $id)->get()->each(function (User $user) use ($deletedAt) {
+            $user->deleted_at = $deletedAt;
+            $user->save();
+        });
+
+        SisaCuti::where('id_karyawan', $id)->whereNull('deleted_at')->get()->each(function ($row) use ($deletedAt) {
+            $row->deleted_at = $deletedAt;
+            $row->save();
+        });
+        KaryawanCutiBersama::where('id_karyawan', $id)->whereNull('deleted_at')->get()->each(function ($row) use ($deletedAt) {
+            $row->deleted_at = $deletedAt;
+            $row->save();
+        });
+
+        $permintaan = PermintaanCuti::where('id_karyawan', $id)->whereNull('deleted_at')->get();
+        $permintaanIds = $permintaan->pluck('id');
+        RiwayatCuti::whereIn('id_permintaan_cuti', $permintaanIds)->whereNull('deleted_at')->get()->each(function ($row) use ($deletedAt) {
+            $row->deleted_at = $deletedAt;
+            $row->save();
+        });
+        $permintaan->each(function ($row) use ($deletedAt) {
+            $row->deleted_at = $deletedAt;
+            $row->save();
+        });
+
+        DB::table('log_pengurangan_cuti')
+            ->where('id_karyawan', $id)
+            ->whereNull('deleted_at')
+            ->update(['deleted_at' => $deletedAt]);
+
+        $karyawan = Karyawan::find($id);
+        $karyawan->deleted_at = $deletedAt;
+        $karyawan->save();
+    });
+
+    return redirect()->back()->with('error_message', 'Data karyawan berhasil dihapus (soft delete)');
+}
+```
+
+`restore`:
+
+```php
+public function restore($id)
+{
+    $karyawan = Karyawan::withTrashed()->find($id);
+    if (!$karyawan || !$karyawan->trashed()) {
+        return redirect()->back()->with('warning_message', 'Data karyawan terhapus tidak ditemukan');
+    }
+
+    DB::transaction(function () use ($karyawan) {
+        $marker = $karyawan->deleted_at;
+        $from = $marker->copy()->subSeconds(2);
+        $to = $marker->copy()->addSeconds(2);
+
+        User::withTrashed()
+            ->where('id_karyawan', $karyawan->id)
+            ->whereBetween('deleted_at', [$from, $to])
+            ->restore();
+
+        SisaCuti::withTrashed()->where('id_karyawan', $karyawan->id)->whereBetween('deleted_at', [$from, $to])->restore();
+        KaryawanCutiBersama::withTrashed()->where('id_karyawan', $karyawan->id)->whereBetween('deleted_at', [$from, $to])->restore();
+
+        $permintaanIds = PermintaanCuti::withTrashed()
+            ->where('id_karyawan', $karyawan->id)
+            ->whereBetween('deleted_at', [$from, $to])
+            ->pluck('id');
+
+        RiwayatCuti::withTrashed()->whereIn('id_permintaan_cuti', $permintaanIds)->whereBetween('deleted_at', [$from, $to])->restore();
+        PermintaanCuti::withTrashed()->where('id_karyawan', $karyawan->id)->whereBetween('deleted_at', [$from, $to])->restore();
+
+        DB::table('log_pengurangan_cuti')
+            ->where('id_karyawan', $karyawan->id)
+            ->whereBetween('deleted_at', [$from, $to])
+            ->update(['deleted_at' => null]);
+
+        $karyawan->restore();
+    });
+
+    return redirect()->back()->with('message', 'Data karyawan berhasil dipulihkan');
+}
+```
+
+Route:
+
+```php
+Route::post('/{id}/restore', [AdminKaryawanController::class, 'restore'])->name('admin.karyawan.restore');
+```
+
+Place **before** `Route::delete('/{id}'...)` is fine; restore is POST with distinct path.
+
+Update `getKaryawanData` to accept `status`:
+
+```php
+$status = $request->input('status', 'active'); // active|trashed
+$query = Karyawan::with('posisi.unitKerja');
+if ($status === 'trashed') {
+    $query->onlyTrashed();
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `php artisan test --filter=KaryawanSoftDeleteTest`
+
+- [ ] **Step 5: Skip commit**
+
+---
+
+### Task 4: UI admin karyawan (filter + restore + fix delete URL)
+
+**Files:**
+- Modify: `resources/views/admin/karyawan.blade.php`
+
+**Interfaces:**
+- Consumes: `admin.karyawan.data?status=`, `admin.karyawan.restore`, `admin.delete-karyawan`
+- Produces: toggle Aktif/Terhapus; restore button; correct delete form action
+
+- [ ] **Step 1: Fix delete form action**
+
+Current bug: JS sets `/admin/delete-karyawan/${id}` tetapi route sebenarnya `/admin/karyawan/{id}`.
+
+```javascript
+$('#deleteEmployeeForm').attr('action', `/admin/karyawan/${id}`);
+```
+
+- [ ] **Step 2: Add status filter UI + pass to fetch**
+
+Add buttons/tabs “Aktif” / “Terhapus”. Keep `let statusFilter = 'active';`.
+
+```javascript
+fetch(`{{ route('admin.karyawan.data') }}?page=${currentPage}&per_page=${perPage}&search=${encodeURIComponent(searchQuery)}&status=${statusFilter}`)
+```
+
+- [ ] **Step 3: Render Restore vs Delete**
+
+If `statusFilter === 'trashed'`, show restore button only:
+
+```javascript
+<button class="btn btn-sm btn-success" onclick="confirmRestore(${item.id}, '${item.nama}')">
+  <span class="material-icons">restore</span>
+</button>
+```
+
+Add restore confirmation modal + form:
+
+```html
+<form id="restoreEmployeeForm" method="post">
+  @csrf
+  <button type="submit" class="btn btn-success">Pulihkan</button>
+</form>
+```
+
+```javascript
+$('#restoreEmployeeForm').attr('action', `/admin/karyawan/${id}/restore`);
+```
+
+Keep NIK warning text on delete modal as-is.
+
+- [ ] **Step 4: Manual UI smoke** (local browser if app up) — skip if DB unreachable; rely on tests for backend
+
+- [ ] **Step 5: Skip commit**
+
+---
+
+### Task 5: UI admin user reset password + fix delete URL
+
+**Files:**
+- Modify: `resources/views/admin/user.blade.php`
+
+**Interfaces:**
+- Consumes: `admin.user.reset-password`
+- Produces: modal reset password per row
+
+- [ ] **Step 1: Fix delete URL**
+
+```javascript
+$('#deleteEmployeeForm').attr('action', `/admin/user/${id}`);
+```
+
+- [ ] **Step 2: Add reset password button + modal**
+
+In `renderTable` actions:
+
+```javascript
+<button class="btn btn-sm btn-info" onclick="openResetPassword(${item.id}, '${item.username}')">
+  <span class="material-icons">lock_reset</span>
+</button>
+```
+
+Modal form:
+
+```html
+<form method="post" action="{{ route('admin.user.reset-password') }}">
+  @csrf
+  @method('PUT')
+  <input type="hidden" name="id" id="resetUserId" />
+  <input type="password" name="password" required minlength="3" />
+  <input type="password" name="password_confirmation" required minlength="3" />
+  <button type="submit" class="btn btn-primary">Reset Password</button>
+</form>
+```
+
+- [ ] **Step 3: Skip commit**
+
+---
+
+### Task 6: Verification checklist (no prod writes)
+
+**Files:** none (checklist)
+
+- [ ] **Step 1: Run full related tests**
+
+```bash
+php artisan test --filter='PasswordHashingTest|KaryawanSoftDeleteTest'
+```
+
+Expected: all PASS. Confirm process **tidak** memakai `DB_*` production (phpunit forces sqlite memory).
+
+- [ ] **Step 2: Provide manual SELECT for `palai_manajer`** (user/DBA runs when DB reachable)
+
+Use SQL from spec. Jika `pw_prefix` OK tapi login gagal → reset via admin UI setelah deploy. Jika `user_deleted` set → restore karyawan terkait.
+
+- [ ] **Step 3: Remind user** — migration file belum dijalankan ke production; minta izin eksplisit sebelum `php artisan migrate` di server.
+
+- [ ] **Step 4: Skip commit** until user asks
+
+---
+
+## Self-review (plan vs spec)
+
+| Spec requirement | Task |
+|------------------|------|
+| Fix double-hash create/change | Task 2 |
+| Admin reset password | Task 2 + 5 |
+| Soft-delete karyawan + users + related | Task 3 |
+| Restore with related window | Task 3 |
+| UI filter + restore | Task 4 |
+| No prod DB damage; sqlite tests | Global + Task 6 |
+| `deleted_at` verification/migration | Task 1 |
+| Manual SELECT diagnostics | Task 6 |
+| Fix wrong delete URLs (discovered) | Task 4 + 5 |
+
+No TBD placeholders. Commit steps deferred per user request.

--- a/docs/superpowers/specs/2026-07-27-soft-delete-karyawan-login-fix-design.md
+++ b/docs/superpowers/specs/2026-07-27-soft-delete-karyawan-login-fix-design.md
@@ -1,0 +1,122 @@
+# Soft-delete karyawan + perbaikan login password
+
+Date: 2026-07-27  
+Status: approved for planning (pending user review of this file)  
+Approach: minimal fix (existing controllers + SoftDeletes)
+
+## Problem
+
+1. Beberapa akun (contoh: `palai_manajer`) gagal login dengan pesan **“Username atau Password Anda Salah”** (`Auth::attempt` gagal).
+2. Admin butuh kemampuan menonaktifkan karyawan (pensiun/MBT/keluar) tanpa hard delete, termasuk akun login terkait, dan bisa di-restore.
+
+## Findings (read-only)
+
+- `User` dan `Karyawan` sudah memakai `SoftDeletes`.
+- `AdminKaryawanController::delete` sudah soft-delete related cuti, tapi **menolak** hapus jika masih ada user aktif.
+- UI hapus karyawan sudah ada di `admin/karyawan`.
+- Risiko kuat double-hash: `User` cast `'password' => 'hashed'` + `AdminUserController` memakai `bcrypt()` + `PasswordController` memakai `Hash::make()`.
+- Host DB production di `.env` tidak reachable dari environment agent; dump lokal (Jan 2026) tidak berisi `palai_*`. Diagnosa akun spesifik lewat SELECT manual saat DB accessible.
+
+## Goals
+
+- Password di-hash **sekali** saat create/change/reset.
+- Admin bisa reset password user tanpa current password.
+- Soft-delete karyawan → soft-delete semua user terkait + related soft-deletable records (pola existing).
+- Restore karyawan → restore user + related yang ikut dihapus pada aksi itu.
+- UI filter aktif/terhapus + tombol restore.
+- Tidak merusak DB/env production dari agent; test memakai sqlite `:memory:` (`phpunit.xml`).
+
+## Non-goals
+
+- Hard delete.
+- Migrasi skema baru kecuali verifikasi membuktikan kolom `deleted_at` belum ada di DB live (model sudah SoftDeletes).
+- Refactor auth/role besar.
+- Mass password fix tanpa aksi admin per akun.
+- Pesan login khusus untuk user soft-deleted (tetap pesan generic di v1).
+
+## Design
+
+### Password / login
+
+| Lokasi | Perubahan |
+|--------|-----------|
+| `AdminUserController::tambahUser` | Simpan password plain string; biarkan cast `hashed` |
+| `PasswordController` | Assign plain password; jangan `Hash::make` manual |
+| `AdminUserController` + `admin/user` view | Endpoint + UI **reset password** (admin set password baru) |
+| `LoginController` | Tidak diubah alur role; soft-deleted user tetap gagal attempt |
+
+### Soft-delete & restore karyawan
+
+`AdminKaryawanController::delete($id)` dalam transaksi:
+
+1. Soft-delete semua `User` dengan `id_karyawan = $id` (termasuk yang aktif).
+2. Soft-delete related: `SisaCuti`, `KaryawanCutiBersama`, `PermintaanCuti` (+ `RiwayatCuti` terkait), `log_pengurangan_cuti`.
+3. Soft-delete `Karyawan`.
+4. Hapus blocker “masih ada user → tolak”.
+
+`AdminKaryawanController::restore($id)` dalam transaksi:
+
+1. `Karyawan::withTrashed()->findOrFail` → `restore()`.
+2. Restore semua `User` trashed untuk `id_karyawan`.
+3. Restore related records milik karyawan yang soft-deleted **pada window yang sama** dengan `deleted_at` karyawan (hindari menghidupkan data yang sudah dihapus sebelumnya tidak terkait pensiun).
+
+Route baru: `POST/PATCH` restore (mis. `admin/karyawan/{id}/restore`).
+
+### UI
+
+- `admin/karyawan`: query `status=active|trashed` (default `active`); tombol Hapus vs Restore.
+- `admin/user`: tombol Reset Password; list default user aktif (user ikut hilang dari list saat soft-delete).
+
+### NIK
+
+Soft-delete tidak menghapus baris; unique NIK tetap terpakai oleh row soft-deleted. UI tetap peringatkan. Restore mengembalikan NIK yang sama.
+
+## Error handling
+
+- Hapus/restore id tidak valid atau state salah → flash warning, no crash.
+- Multi-user per karyawan → semua ikut soft-delete/restore.
+- Gagal di tengah transaksi → rollback penuh.
+
+## Diagnostics (manual, SELECT only)
+
+Saat DB reachable, cek akun bermasalah:
+
+```sql
+SELECT u.id, u.username, u.deleted_at AS user_deleted,
+       LENGTH(u.password) AS pw_len, LEFT(u.password, 7) AS pw_prefix,
+       k.id AS karyawan_id, k.nama, k.deleted_at AS karyawan_deleted,
+       r.nama_role
+FROM users u
+LEFT JOIN karyawan k ON k.id = u.id_karyawan
+LEFT JOIN posisi p ON p.id = k.id_posisi
+LEFT JOIN role r ON r.id = p.id_role
+WHERE u.username = 'palai_manajer';
+```
+
+Interpretasi cepat: `user_deleted` tidak null → soft-deleted; `pw_prefix` bukan `$2y$12$` / hash aneh → kemungkinan corrupt/double-hash; role null → masalah posisi (biasanya pesan B, bukan A).
+
+Perbaikan akun: admin reset password (setelah fix double-hash), atau restore jika soft-deleted.
+
+## Testing
+
+- Feature tests di `tests/Feature` dengan sqlite memory (sudah di `phpunit.xml`).
+- Kasus wajib:
+  1. Create user → `Auth::attempt` sukses dengan password plain.
+  2. Soft-delete karyawan → user tidak lolos `Auth::attempt`.
+  3. Restore karyawan → user bisa login lagi.
+  4. Reset password admin → login dengan password baru.
+- Jangan mengarahkan test ke DB production `.env`.
+
+## Files likely touched
+
+- `app/Http/Controllers/admin/AdminKaryawanController.php`
+- `app/Http/Controllers/admin/AdminUserController.php`
+- `app/Http/Controllers/PasswordController.php`
+- `resources/views/admin/karyawan.blade.php`
+- `resources/views/admin/user.blade.php`
+- `routes/web.php`
+- `tests/Feature/...` (baru)
+
+## Open verification before implement
+
+- Konfirmasi kolom `deleted_at` ada di tabel live `users` / `karyawan` / related (SELECT schema only). Jika belum, baru tulis migration file — **jangan jalankan migrate** tanpa perintah eksplisit user.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/resources/views/admin/karyawan.blade.php
+++ b/resources/views/admin/karyawan.blade.php
@@ -14,12 +14,20 @@
             <div class="card">
                 <div class="card-header">
                     <h5>Data Karyawan</h5>
-                    <div class="row">
+                    <div class="row align-items-center">
                         <div class="col">
                             <button type="button" class="btn btn-primary" data-bs-toggle="modal"
                                 data-bs-target="#exampleModal">
                                 + Tambah Karyawan
                             </button>
+                        </div>
+                        <div class="col-auto">
+                            <div class="btn-group" role="group" aria-label="Status filter">
+                                <button type="button" class="btn btn-outline-secondary active" id="filterActiveBtn"
+                                    onclick="setStatusFilter('active')">Aktif</button>
+                                <button type="button" class="btn btn-outline-secondary" id="filterTrashedBtn"
+                                    onclick="setStatusFilter('trashed')">Terhapus</button>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -258,6 +266,29 @@
             </div>
         </div>
     </div>
+
+    <!-- Restore Confirmation Modal -->
+    <div class="modal fade" id="restoreConfirmationModal" tabindex="-1" aria-labelledby="restoreConfirmationModalLabel"
+        aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="restoreConfirmationModalLabel">Konfirmasi Pemulihan</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p>Pulihkan data <b><span id="restoreEmployeeName"></span></b> beserta akun user terkait?</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Batalkan</button>
+                    <form id="restoreEmployeeForm" action="" method="post" style="display: inline;">
+                        @csrf
+                        <button type="submit" class="btn btn-success">Pulihkan</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
 @endsection
 @section('script')
     <script src="{{ asset('assets/plugins/notifications/js/lobibox.min.js') }}"></script>
@@ -322,10 +353,26 @@
 
         function confirmDelete(id, name) {
             $('#employeeName').text(name);
-            $('#deleteEmployeeForm').attr('action', `/admin/delete-karyawan/${id}`);
+            $('#deleteEmployeeForm').attr('action', `/admin/karyawan/${id}`);
             const deleteModalEl = document.getElementById('deleteConfirmationModal');
             const deleteModal = bootstrap.Modal.getInstance(deleteModalEl) || new bootstrap.Modal(deleteModalEl);
             deleteModal.show();
+        }
+
+        function confirmRestore(id, name) {
+            $('#restoreEmployeeName').text(name);
+            $('#restoreEmployeeForm').attr('action', `/admin/karyawan/${id}/restore`);
+            const restoreModalEl = document.getElementById('restoreConfirmationModal');
+            const restoreModal = bootstrap.Modal.getInstance(restoreModalEl) || new bootstrap.Modal(restoreModalEl);
+            restoreModal.show();
+        }
+
+        function setStatusFilter(status) {
+            statusFilter = status;
+            currentPage = 1;
+            document.getElementById('filterActiveBtn').classList.toggle('active', status === 'active');
+            document.getElementById('filterTrashedBtn').classList.toggle('active', status === 'trashed');
+            loadKaryawanData();
         }
 
 
@@ -403,12 +450,13 @@
         let searchQuery = '';
         let searchTimeout;
         let totalPages = 1;
+        let statusFilter = 'active';
 
         function loadKaryawanData() {
             const tableBody = document.getElementById('tableBody');
             tableBody.innerHTML = '<tr><td colspan="9" class="text-center">Loading...</td></tr>';
 
-            fetch(`{{ route('admin.karyawan.data') }}?page=${currentPage}&per_page=${perPage}&search=${searchQuery}`)
+            fetch(`{{ route('admin.karyawan.data') }}?page=${currentPage}&per_page=${perPage}&search=${encodeURIComponent(searchQuery)}&status=${statusFilter}`)
                 .then(response => response.json())
                 .then(data => {
                     renderTable(data);
@@ -432,26 +480,37 @@
             let html = '';
             data.data.forEach((item, index) => {
                 const no = ((data.current_page - 1) * data.per_page) + index + 1;
+                const nik = item.nik || item.NIK || '-';
+                const safeName = String(item.nama || '').replace(/'/g, "\\'");
+                let actions = '';
+                if (statusFilter === 'trashed') {
+                    actions = `
+                            <button class="btn btn-sm px-2 py-0 m-0 btn-success"
+                                onclick="confirmRestore(${item.id}, '${safeName}')">
+                                <span class="material-icons">restore</span>
+                            </button>`;
+                } else {
+                    actions = `
+                            <button class="btn btn-sm px-2 py-0 m-0 btn-warning"
+                                onclick="editEmployee(${item.id})">
+                                <span class="material-icons">edit_note</span>
+                            </button>
+                            <button class="btn btn-sm px-2 py-0 m-0 btn-danger"
+                                onclick="confirmDelete(${item.id}, '${safeName}')">
+                                <span class="material-icons">delete</span>
+                            </button>`;
+                }
                 html += `
                     <tr class="text-center align-middle">
                         <th>${no}</th>
-                        <td>${item.NIK}</td>
+                        <td>${nik}</td>
                         <td>${item.nama}</td>
                         <td>${item.jabatan}</td>
                         <td>${item.posisi?.unit_kerja?.nama_unit_kerja || '-'}</td>
                         <td>${item.posisi?.jabatan || '-'}</td>
                         <td>${item.id_posisi}</td>
                         <td>${item.id}</td>
-                        <td>
-                            <button class="btn btn-sm px-2 py-0 m-0 btn-warning"
-                                onclick="editEmployee(${item.id})">
-                                <span class="material-icons">edit_note</span>
-                            </button>
-                            <button class="btn btn-sm px-2 py-0 m-0 btn-danger"
-                                onclick="confirmDelete(${item.id}, '${item.nama}')">
-                                <span class="material-icons">delete</span>
-                            </button>
-                        </td>
+                        <td>${actions}</td>
                     </tr>
                 `;
             });

--- a/resources/views/admin/user.blade.php
+++ b/resources/views/admin/user.blade.php
@@ -202,6 +202,41 @@
             </div>
         </div>
     </div>
+
+    <!-- Reset Password Modal -->
+    <div class="modal fade" id="resetPasswordModal" tabindex="-1" aria-labelledby="resetPasswordModalLabel"
+        aria-hidden="true">
+        <div class="modal-dialog">
+            <form method="post" action="{{ route('admin.user.reset-password') }}">
+                @csrf
+                @method('PUT')
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="resetPasswordModalLabel">Reset Password</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Reset password untuk user <b><span id="resetUsername"></span></b></p>
+                        <input type="hidden" name="id" id="resetUserId" />
+                        <div class="mb-3">
+                            <label class="form-label" for="resetPassword">Password Baru</label>
+                            <input type="password" class="form-control" name="password" id="resetPassword" required
+                                minlength="3" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="resetPasswordConfirmation">Konfirmasi Password</label>
+                            <input type="password" class="form-control" name="password_confirmation"
+                                id="resetPasswordConfirmation" required minlength="3" />
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Batalkan</button>
+                        <button type="submit" class="btn btn-primary">Reset Password</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
 @endsection
 @section('script')
     <script type="text/javascript" src="https://cdn.jsdelivr.net/jquery/latest/jquery.min.js"></script>
@@ -276,9 +311,19 @@
         }
 
         function confirmDelete(id, name) {
-            $('#employeeName').text(name); // Set the employee name in the modal
-            $('#deleteEmployeeForm').attr('action', `/admin/delete-user/${id}`); // Set the form action URL
-            $('#deleteConfirmationModal').modal('show'); // Show the confirmation modal
+            $('#employeeName').text(name);
+            $('#deleteEmployeeForm').attr('action', `/admin/user/${id}`);
+            $('#deleteConfirmationModal').modal('show');
+        }
+
+        function openResetPassword(id, username) {
+            $('#resetUserId').val(id);
+            $('#resetUsername').text(username);
+            $('#resetPassword').val('');
+            $('#resetPasswordConfirmation').val('');
+            const modalEl = document.getElementById('resetPasswordModal');
+            const modal = bootstrap.Modal.getInstance(modalEl) || new bootstrap.Modal(modalEl);
+            modal.show();
         }
 
 
@@ -388,6 +433,8 @@
             data.data.forEach((item, index) => {
                 const no = ((data.current_page - 1) * data.per_page) + index + 1;
                 const namaKaryawan = item.karyawan ? item.karyawan.nama : '-';
+                const safeNama = String(namaKaryawan).replace(/'/g, "\\'");
+                const safeUsername = String(item.username || '').replace(/'/g, "\\'");
                 html += `
                     <tr class="text-center align-middle">
                         <th>${no}</th>
@@ -400,8 +447,12 @@
                                 data-bs-target="#editUserModal">
                                 <span class="material-icons">edit_note</span>
                             </button>
+                            <button class="btn btn-sm px-2 py-0 m-0 btn-info"
+                                onclick="openResetPassword(${item.id}, '${safeUsername}')">
+                                <span class="material-icons">lock_reset</span>
+                            </button>
                             <button class="btn btn-sm px-2 py-0 m-0 btn-danger"
-                                onclick="confirmDelete(${item.id}, '${namaKaryawan}')">
+                                onclick="confirmDelete(${item.id}, '${safeNama}')">
                                 <span class="material-icons">delete</span>
                             </button>
                         </td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -98,6 +98,7 @@ Route::group(['prefix' => 'admin', 'middleware' => ['admin.auth']], function () 
             Route::get('/{id}/edit', [AdminKaryawanController::class , 'edit'])->name('admin.karyawan.edit');
             Route::post('/', [AdminKaryawanController::class , 'tambahKaryawan'])->name('tambahKaryawan');
             Route::put('/update', [AdminKaryawanController::class , 'updateKaryawan'])->name('updateKaryawan');
+            Route::post('/{id}/restore', [AdminKaryawanController::class , 'restore'])->name('admin.karyawan.restore');
             Route::delete('/{id}', [AdminKaryawanController::class , 'delete'])->name('admin.delete-karyawan');
         }
         );
@@ -109,6 +110,7 @@ Route::group(['prefix' => 'admin', 'middleware' => ['admin.auth']], function () 
             Route::get('/{id}/edit', [AdminUserController::class , 'edit'])->name('admin.user.edit');
             Route::post('/', [AdminUserController::class , 'tambahUser'])->name('tambahUser');
             Route::put('/update', [AdminUserController::class , 'updateUser'])->name('updateUser');
+            Route::put('/reset-password', [AdminUserController::class , 'resetPassword'])->name('admin.user.reset-password');
             Route::delete('/{id}', [AdminUserController::class , 'delete'])->name('admin.delete-user');
         }
         );

--- a/tests/Feature/KaryawanSoftDeleteTest.php
+++ b/tests/Feature/KaryawanSoftDeleteTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\admin\AdminKaryawanController;
+use App\Models\Karyawan;
+use App\Models\Posisi;
+use App\Models\Role;
+use App\Models\UnitKerja;
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class KaryawanSoftDeleteTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->createMinimalAuthSchema();
+    }
+
+    private function createMinimalAuthSchema(): void
+    {
+        Schema::dropIfExists('users');
+        Schema::dropIfExists('karyawan');
+        Schema::dropIfExists('posisi');
+        Schema::dropIfExists('role');
+        Schema::dropIfExists('unit_kerja');
+        Schema::dropIfExists('sisa_cuti');
+        Schema::dropIfExists('karyawan_cuti_bersama');
+        Schema::dropIfExists('permintaan_cuti');
+        Schema::dropIfExists('riwayat_cuti');
+        Schema::dropIfExists('log_pengurangan_cuti');
+
+        Schema::create('unit_kerja', function (Blueprint $t) {
+            $t->id();
+            $t->string('kode_unit_kerja')->nullable();
+            $t->string('nama_unit_kerja')->nullable();
+            $t->string('bagian')->nullable();
+            $t->boolean('is_kebun')->default(0);
+            $t->timestamps();
+        });
+        Schema::create('role', function (Blueprint $t) {
+            $t->id();
+            $t->string('nama_role');
+            $t->timestamps();
+        });
+        Schema::create('posisi', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('id_unit_kerja');
+            $t->unsignedBigInteger('id_role');
+            $t->string('jabatan')->nullable();
+            $t->timestamps();
+        });
+        Schema::create('karyawan', function (Blueprint $t) {
+            $t->id();
+            $t->string('nik');
+            $t->string('nama');
+            $t->string('jabatan')->nullable();
+            $t->date('tmt_bekerja')->nullable();
+            $t->date('tgl_diangkat_staf')->nullable();
+            $t->unsignedBigInteger('id_posisi');
+            $t->timestamps();
+            $t->softDeletes();
+        });
+        Schema::create('users', function (Blueprint $t) {
+            $t->id();
+            $t->string('username');
+            $t->string('password');
+            $t->unsignedBigInteger('id_karyawan');
+            $t->string('kode_unit')->nullable();
+            $t->rememberToken();
+            $t->timestamps();
+            $t->softDeletes();
+        });
+        Schema::create('sisa_cuti', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('id_karyawan');
+            $t->unsignedBigInteger('id_jenis_cuti')->nullable();
+            $t->date('periode_mulai')->nullable();
+            $t->date('periode_akhir')->nullable();
+            $t->integer('jumlah')->default(0);
+            $t->timestamps();
+            $t->softDeletes();
+        });
+        Schema::create('karyawan_cuti_bersama', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('id_karyawan');
+            $t->date('tanggal')->nullable();
+            $t->timestamps();
+            $t->softDeletes();
+        });
+        Schema::create('permintaan_cuti', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('id_karyawan');
+            $t->timestamps();
+            $t->softDeletes();
+        });
+        Schema::create('riwayat_cuti', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('id_permintaan_cuti');
+            $t->timestamps();
+            $t->softDeletes();
+        });
+        Schema::create('log_pengurangan_cuti', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('id_karyawan');
+            $t->timestamps();
+            $t->softDeletes();
+        });
+    }
+
+    private function seedUserWithKaryawan(string $username, string $password): array
+    {
+        $unit = UnitKerja::create([
+            'kode_unit_kerja' => 'T1',
+            'nama_unit_kerja' => 'Test',
+            'is_kebun' => 0,
+        ]);
+        $role = Role::create(['nama_role' => 'manajer']);
+        $posisi = Posisi::create([
+            'id_unit_kerja' => $unit->id,
+            'id_role' => $role->id,
+            'jabatan' => 'Manajer',
+        ]);
+        $karyawan = Karyawan::create([
+            'nik' => (string) random_int(100000, 999999),
+            'nama' => 'Test Manajer',
+            'jabatan' => 'Manajer',
+            'tmt_bekerja' => '2020-01-01',
+            'id_posisi' => $posisi->id,
+        ]);
+        $user = User::create([
+            'username' => $username,
+            'password' => $password,
+            'id_karyawan' => $karyawan->id,
+        ]);
+
+        return [$karyawan, $user];
+    }
+
+    public function test_soft_delete_karyawan_soft_deletes_users_and_blocks_login(): void
+    {
+        [$karyawan, $user] = $this->seedUserWithKaryawan('soft_del_user', 'secret123');
+        $this->assertTrue(Auth::attempt(['username' => 'soft_del_user', 'password' => 'secret123']));
+        Auth::logout();
+
+        $controller = app(AdminKaryawanController::class);
+        $controller->delete($karyawan->id);
+
+        $this->assertNull(Karyawan::find($karyawan->id));
+        $this->assertTrue(Karyawan::withTrashed()->find($karyawan->id)->trashed());
+        $this->assertNull(User::where('username', 'soft_del_user')->first());
+        $this->assertTrue(User::withTrashed()->where('username', 'soft_del_user')->first()->trashed());
+        $this->assertFalse(Auth::attempt(['username' => 'soft_del_user', 'password' => 'secret123']));
+    }
+
+    public function test_restore_karyawan_restores_user_and_login(): void
+    {
+        [$karyawan] = $this->seedUserWithKaryawan('restore_user', 'secret123');
+        $controller = app(AdminKaryawanController::class);
+        $controller->delete($karyawan->id);
+        $controller->restore($karyawan->id);
+
+        $this->assertNotNull(Karyawan::find($karyawan->id));
+        $this->assertNotNull(User::where('username', 'restore_user')->first());
+        $this->assertTrue(Auth::attempt(['username' => 'restore_user', 'password' => 'secret123']));
+    }
+
+    public function test_get_karyawan_data_supports_trashed_filter(): void
+    {
+        [$karyawan] = $this->seedUserWithKaryawan('filter_user', 'secret123');
+        $controller = app(AdminKaryawanController::class);
+        $controller->delete($karyawan->id);
+
+        $active = $controller->getKaryawanData(Request::create('/admin/karyawan/data', 'GET', [
+            'status' => 'active',
+            'per_page' => 25,
+            'page' => 1,
+        ]));
+        $trashed = $controller->getKaryawanData(Request::create('/admin/karyawan/data', 'GET', [
+            'status' => 'trashed',
+            'per_page' => 25,
+            'page' => 1,
+        ]));
+
+        $this->assertSame(0, $active->getData(true)['total']);
+        $this->assertSame(1, $trashed->getData(true)['total']);
+    }
+}

--- a/tests/Feature/PasswordHashingTest.php
+++ b/tests/Feature/PasswordHashingTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Karyawan;
+use App\Models\Posisi;
+use App\Models\Role;
+use App\Models\UnitKerja;
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class PasswordHashingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->createMinimalAuthSchema();
+    }
+
+    private function createMinimalAuthSchema(): void
+    {
+        Schema::dropIfExists('users');
+        Schema::dropIfExists('karyawan');
+        Schema::dropIfExists('posisi');
+        Schema::dropIfExists('role');
+        Schema::dropIfExists('unit_kerja');
+
+        Schema::create('unit_kerja', function (Blueprint $t) {
+            $t->id();
+            $t->string('kode_unit_kerja')->nullable();
+            $t->string('nama_unit_kerja')->nullable();
+            $t->string('bagian')->nullable();
+            $t->boolean('is_kebun')->default(0);
+            $t->timestamps();
+        });
+        Schema::create('role', function (Blueprint $t) {
+            $t->id();
+            $t->string('nama_role');
+            $t->timestamps();
+        });
+        Schema::create('posisi', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('id_unit_kerja');
+            $t->unsignedBigInteger('id_role');
+            $t->string('jabatan')->nullable();
+            $t->timestamps();
+        });
+        Schema::create('karyawan', function (Blueprint $t) {
+            $t->id();
+            $t->string('nik');
+            $t->string('nama');
+            $t->string('jabatan')->nullable();
+            $t->date('tmt_bekerja')->nullable();
+            $t->date('tgl_diangkat_staf')->nullable();
+            $t->unsignedBigInteger('id_posisi');
+            $t->timestamps();
+            $t->softDeletes();
+        });
+        Schema::create('users', function (Blueprint $t) {
+            $t->id();
+            $t->string('username');
+            $t->string('password');
+            $t->unsignedBigInteger('id_karyawan');
+            $t->string('kode_unit')->nullable();
+            $t->rememberToken();
+            $t->timestamps();
+            $t->softDeletes();
+        });
+    }
+
+    private function seedManajerUser(string $username, string $plainPassword): User
+    {
+        $unit = UnitKerja::create([
+            'kode_unit_kerja' => 'T1',
+            'nama_unit_kerja' => 'Test',
+            'is_kebun' => 0,
+        ]);
+        $role = Role::create(['nama_role' => 'manajer']);
+        $posisi = Posisi::create([
+            'id_unit_kerja' => $unit->id,
+            'id_role' => $role->id,
+            'jabatan' => 'Manajer',
+        ]);
+        $karyawan = Karyawan::create([
+            'nik' => (string) random_int(100000, 999999),
+            'nama' => 'Test Manajer',
+            'jabatan' => 'Manajer',
+            'tmt_bekerja' => '2020-01-01',
+            'id_posisi' => $posisi->id,
+        ]);
+
+        return User::create([
+            'username' => $username,
+            'password' => $plainPassword,
+            'id_karyawan' => $karyawan->id,
+        ]);
+    }
+
+    public function test_user_create_with_plain_password_authenticates(): void
+    {
+        $user = $this->seedManajerUser('palai_manajer', 'secret123');
+
+        $this->assertTrue(Hash::check('secret123', $user->fresh()->password));
+        $this->assertTrue(Auth::attempt([
+            'username' => 'palai_manajer',
+            'password' => 'secret123',
+        ]));
+    }
+
+    public function test_already_hashed_password_assignment_still_authenticates(): void
+    {
+        // Laravel 'hashed' cast skips re-hash when value is already hashed.
+        $unit = UnitKerja::create([
+            'kode_unit_kerja' => 'T2',
+            'nama_unit_kerja' => 'Test2',
+            'is_kebun' => 0,
+        ]);
+        $role = Role::create(['nama_role' => 'manajer']);
+        $posisi = Posisi::create([
+            'id_unit_kerja' => $unit->id,
+            'id_role' => $role->id,
+            'jabatan' => 'Manajer',
+        ]);
+        $karyawan = Karyawan::create([
+            'nik' => '1002',
+            'nama' => 'X',
+            'jabatan' => 'M',
+            'tmt_bekerja' => '2020-01-01',
+            'id_posisi' => $posisi->id,
+        ]);
+
+        $user = new User();
+        $user->username = 'prehashed_user';
+        $user->id_karyawan = $karyawan->id;
+        $user->password = bcrypt('secret123');
+        $user->save();
+
+        $this->assertTrue(Auth::attempt([
+            'username' => 'prehashed_user',
+            'password' => 'secret123',
+        ]));
+    }
+
+    public function test_admin_reset_password_allows_login_with_new_password(): void
+    {
+        $user = $this->seedManajerUser('reset_me', 'oldpass');
+        $user->password = 'newpass99';
+        $user->save();
+
+        $this->assertFalse(Auth::attempt([
+            'username' => 'reset_me',
+            'password' => 'oldpass',
+        ]));
+        $this->assertTrue(Auth::attempt([
+            'username' => 'reset_me',
+            'password' => 'newpass99',
+        ]));
+    }
+}


### PR DESCRIPTION
## Summary
- Soft-delete karyawan sekarang ikut menonaktifkan user terkait (dan data cuti terkait), dengan tombol **Pulihkan** + filter Aktif/Terhapus di admin karyawan.
- Admin bisa **reset password** user tanpa current password; create/change password memakai cast `hashed` (plain string) agar hash konsisten.
- Perbaikan URL hapus yang salah (`/admin/karyawan/{id}`, `/admin/user/{id}`), migration opsional `deleted_at`, dan feature test di sqlite memory (bukan DB production).

## Catatan deploy
- Jalankan migration `2026_07_27_000001_add_deleted_at_to_soft_delete_tables` **hanya jika** kolom `deleted_at` belum ada di tabel terkait.
- Akun gagal login (contoh `palai_manajer`): setelah deploy, cek status soft-delete lalu gunakan **Reset Password** di Admin → User.

## Test plan
- [ ] `php artisan test --filter='PasswordHashingTest|KaryawanSoftDeleteTest'` lulus
- [ ] Admin → Karyawan: hapus karyawan yang punya user → user hilang dari list & tidak bisa login
- [ ] Filter **Terhapus** → **Pulihkan** → user bisa login lagi
- [ ] Admin → User → Reset Password → login dengan password baru
- [ ] Pastikan tidak ada write ke DB production dari suite test (sqlite `:memory:`)


Made with [Cursor](https://cursor.com)